### PR TITLE
fix(time_window): make time_window behave as size of window and not m…

### DIFF
--- a/src/core_server/internal/ceql/query/within.hpp
+++ b/src/core_server/internal/ceql/query/within.hpp
@@ -40,7 +40,12 @@ struct Within {
     }
 
     TimeWindow(uint64_t time_interval, std::string_view attribute_name, TimeWindowMode mode)
-        : mode(mode), attribute_name(attribute_name), duration(time_interval) {
+        : mode(mode), attribute_name(attribute_name), duration(time_interval - 1) {
+      if (time_interval == 0) {
+        throw std::logic_error(
+          "Cannot use a time window of less then 1, due to needing at least the "
+          "receiving event to fit in the window");
+      }
       switch (mode) {
         case NONE:
           throw std::logic_error(

--- a/src/unit_tests/core_server/internal/evaluation/evaluation_algorithm/within-custom.cpp
+++ b/src/unit_tests/core_server/internal/evaluation/evaluation_algorithm/within-custom.cpp
@@ -280,6 +280,135 @@ TEST_CASE("Evaluation on the example stream of the papers Within smaller") {
 
   output = result_handler.get_enumerator();
 
+  REQUIRE(output.complex_events.size() == 0);
+}
+
+TEST_CASE("Evaluation on the example stream of the papers Within smaller + 1") {
+  Internal::Interface::Backend<TestResultHandler> backend;
+  TestResultHandler result_handler{backend.get_catalog_reference()};
+
+  auto event_type_id_1 = backend.add_event_type("SELL",
+                                                {{"name", Types::ValueTypes::STRING_VIEW},
+                                                 {"price", Types::ValueTypes::INT64},
+                                                 {"stock_time", Types::ValueTypes::INT64}});
+  auto event_type_id_2 = backend.add_event_type("BUY",
+                                                {{"name", Types::ValueTypes::STRING_VIEW},
+                                                 {"price", Types::ValueTypes::INT64},
+                                                 {"volume", Types::ValueTypes::INT64},
+                                                 {"stock_time", Types::ValueTypes::INT64}});
+
+  auto stream_type = backend.add_stream_type("Stock", {event_type_id_1, event_type_id_2});
+
+  std::string string_query =
+    "SELECT * FROM Stock\n"
+    "WHERE SELL as msft; SELL as intel; SELL as amzn\n"
+    "FILTER msft[name='MSFT'] AND msft[price > 100]\n"
+    "    AND intel[name='INTL']\n"
+    "    AND amzn[name='AMZN'] AND amzn[price < 2000]\n"
+    "WITHIN 6 [stock_time]";
+
+  backend.declare_query(string_query, result_handler);
+
+  Types::Event event;
+  Types::Enumerator output;
+
+  event = {0,
+           {std::make_shared<Types::StringValue>("MSFT"),
+            std::make_shared<Types::IntValue>(101),
+            std::make_shared<Types::IntValue>(0)}};
+  INFO("SELL MSFT 101");
+
+  backend.send_event_to_queries(0, event);
+
+  output = result_handler.get_enumerator();
+
+  REQUIRE(output.complex_events.size() == 0);
+
+  event = {0,
+           {std::make_shared<Types::StringValue>("MSFT"),
+            std::make_shared<Types::IntValue>(102),
+            std::make_shared<Types::IntValue>(1)}};
+  INFO("SELL MSFT 102");
+
+  backend.send_event_to_queries(0, event);
+
+  output = result_handler.get_enumerator();
+
+  REQUIRE(output.complex_events.size() == 0);
+
+  event = {0,
+           {std::make_shared<Types::StringValue>("INTL"),
+            std::make_shared<Types::IntValue>(80),
+            std::make_shared<Types::IntValue>(2)}};
+  INFO("SELL INTL 80");
+
+  backend.send_event_to_queries(0, event);
+
+  output = result_handler.get_enumerator();
+
+  REQUIRE(output.complex_events.size() == 0);
+
+  event = {1,
+           {std::make_shared<Types::StringValue>("INTL"),
+            std::make_shared<Types::IntValue>(80),
+            std::make_shared<Types::IntValue>(1),
+            std::make_shared<Types::IntValue>(3)}};
+  INFO("BUY INTL 80");
+
+  backend.send_event_to_queries(0, event);
+
+  output = result_handler.get_enumerator();
+
+  REQUIRE(output.complex_events.size() == 0);
+
+  event = {0,
+           {std::make_shared<Types::StringValue>("AMZN"),
+            std::make_shared<Types::IntValue>(1900),
+            std::make_shared<Types::IntValue>(4)}};
+  INFO("SELL AMZN 1900");
+
+  backend.send_event_to_queries(0, event);
+
+  output = result_handler.get_enumerator();
+
+  REQUIRE(output.complex_events.size() == 2);
+  REQUIRE(output.complex_events[0].start == 1);
+  REQUIRE(output.complex_events[0].end == 4);
+  REQUIRE(output.complex_events[1].start == 0);
+  REQUIRE(output.complex_events[1].end == 4);
+
+  REQUIRE(output.complex_events[0].events.size() == 3);
+  REQUIRE(is_the_same_as(output.complex_events[0].events[0], 0, "MSFT", 102));
+  REQUIRE(is_the_same_as(output.complex_events[0].events[1], 0, "INTL", 80));
+  REQUIRE(is_the_same_as(output.complex_events[0].events[2], 0, "AMZN", 1900));
+
+  REQUIRE(output.complex_events[1].events.size() == 3);
+  REQUIRE(is_the_same_as(output.complex_events[1].events[0], 0, "MSFT", 101));
+  REQUIRE(is_the_same_as(output.complex_events[1].events[1], 0, "INTL", 80));
+  REQUIRE(is_the_same_as(output.complex_events[1].events[2], 0, "AMZN", 1900));
+
+  event = {0,
+           {std::make_shared<Types::StringValue>("INTL"),
+            std::make_shared<Types::IntValue>(81),
+            std::make_shared<Types::IntValue>(5)}};
+  INFO("SELL INTL 81");
+
+  backend.send_event_to_queries(0, event);
+
+  output = result_handler.get_enumerator();
+
+  REQUIRE(output.complex_events.size() == 0);
+
+  event = {0,
+           {std::make_shared<Types::StringValue>("AMZN"),
+            std::make_shared<Types::IntValue>(1920),
+            std::make_shared<Types::IntValue>(6)}};
+  INFO("SELL AMZN 1920");
+
+  backend.send_event_to_queries(0, event);
+
+  output = result_handler.get_enumerator();
+
   REQUIRE(output.complex_events.size() == 2);
   REQUIRE(output.complex_events[0].start == 1);
   REQUIRE(output.complex_events[0].end == 6);


### PR DESCRIPTION
…aximum difference

Off by one error due to time_window being used internally as the maximum difference betweeen events in a detection. This is wrong due to time_window representing the size of the detection window. This means the original has a +1 range over the other.