### PR TITLE
fix m4 compilation on gnu23

### DIFF
--- a/conan_profiles/aarch64-linux-gcc-libstdc
+++ b/conan_profiles/aarch64-linux-gcc-libstdc
@@ -5,3 +5,7 @@ compiler.cppstd=gnu23
 compiler.libcxx=libstdc++11
 compiler.version=14.2
 os=Linux
+[conf]
+# Force C17 for autotools dependencies (m4, gmp) - fixes C23 incompatibility
+gmp/*:tools.build:cflags=["-std=gnu17"]
+m4/*:tools.build:cflags=["-std=gnu17"]

--- a/conan_profiles/aarch64-macos-clang-libc
+++ b/conan_profiles/aarch64-macos-clang-libc
@@ -7,4 +7,6 @@ compiler.version=19
 os=Macos
 [conf]
 tools.build:compiler_executables={"c": "clang", "cpp": "clang++"}
-
+# Force C17 for autotools dependencies (m4, gmp) - fixes C23 incompatibility
+gmp/*:tools.build:cflags=["-std=gnu17"]
+m4/*:tools.build:cflags=["-std=gnu17"]

--- a/conan_profiles/x86_64-linux-clang-libc
+++ b/conan_profiles/x86_64-linux-clang-libc
@@ -8,3 +8,7 @@ os=Linux
 [buildenv]
 C=clang
 CXX=clang++
+[conf]
+# Force C17 for autotools dependencies (m4, gmp) - fixes C23 incompatibility
+gmp/*:tools.build:cflags=["-std=gnu17"]
+m4/*:tools.build:cflags=["-std=gnu17"]

--- a/conan_profiles/x86_64-linux-clang-libstdc
+++ b/conan_profiles/x86_64-linux-clang-libstdc
@@ -8,3 +8,7 @@ os=Linux
 [buildenv]
 C=clang
 CXX=clang++
+[conf]
+# Force C17 for autotools dependencies (m4, gmp) - fixes C23 incompatibility
+gmp/*:tools.build:cflags=["-std=gnu17"]
+m4/*:tools.build:cflags=["-std=gnu17"]

--- a/conan_profiles/x86_64-linux-gcc-libstdc
+++ b/conan_profiles/x86_64-linux-gcc-libstdc
@@ -5,3 +5,7 @@ compiler.cppstd=gnu23
 compiler.libcxx=libstdc++11
 compiler.version=14.2
 os=Linux
+[conf]
+# Force C17 for autotools dependencies (m4, gmp) - fixes C23 incompatibility
+gmp/*:tools.build:cflags=["-std=gnu17"]
+m4/*:tools.build:cflags=["-std=gnu17"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration profiles across multiple platforms to apply consistent compiler settings. These changes enhance build compatibility and ensure uniform build behavior across different system architectures and compiler combinations (Linux with GCC/Clang and macOS with Clang).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->