### PR TITLE
refactor: use const for speed

### DIFF
--- a/src/core_server/internal/evaluation/det_cea/det_cea.hpp
+++ b/src/core_server/internal/evaluation/det_cea/det_cea.hpp
@@ -49,7 +49,7 @@ class DetCEA {
   }
 
   State::TransitionTargetStatesWithMarkings
-  next(State* state, Bitset evaluation, const uint64_t& current_iteration) {
+  next(State* state, const Bitset& evaluation, const uint64_t& current_iteration) {
     ZoneScopedN("DetCEA::next");
     assert(state != nullptr);
     n_nexts++;
@@ -76,7 +76,9 @@ class DetCEA {
 
  private:
   State::TransitionTargetStatesWithMarkings
-  compute_next_states(State* state, Bitset& evaluation, const uint64_t& current_iteration) {
+  compute_next_states(State* state,
+                      const Bitset& evaluation,
+                      const uint64_t& current_iteration) {
     std::vector<RawStates> computed_raw_states = std::move(
       compute_next_raw_states(state, evaluation));
     std::vector<State*> next_states;
@@ -85,11 +87,12 @@ class DetCEA {
     next_states_marked_variables.reserve(computed_raw_states.size());
 
     for (auto& raw_state : computed_raw_states) {
-      auto states_bitset = raw_state.states;
-      auto marked_variables = raw_state.marked_variables;
-      State* state = state_manager.create_or_return_existing_state(states_bitset, cea);
+      auto states_bitset = std::move(raw_state.states);
+      auto marked_variables = std::move(raw_state.marked_variables);
+      State* state = state_manager.create_or_return_existing_state(std::move(states_bitset),
+                                                                   cea);
       next_states.push_back(state);
-      next_states_marked_variables.push_back(marked_variables);
+      next_states_marked_variables.push_back(std::move(marked_variables));
     }
 
     return {std::move(next_states), std::move(next_states_marked_variables)};
@@ -97,7 +100,6 @@ class DetCEA {
 
   std::vector<RawStates> compute_next_raw_states(State* state, Bitset evaluation) {
     assert(state != nullptr);
-    auto states_bitset = state->states;
     auto states_vector = get_states_from_bitset(state->states);
     std::map<VariablesToMark, StateStates> computed_raw_states;
     for (uint64_t state : states_vector) {

--- a/src/core_server/internal/evaluation/det_cea/det_cea.hpp
+++ b/src/core_server/internal/evaluation/det_cea/det_cea.hpp
@@ -98,7 +98,7 @@ class DetCEA {
     return {std::move(next_states), std::move(next_states_marked_variables)};
   }
 
-  std::vector<RawStates> compute_next_raw_states(State* state, Bitset evaluation) {
+  std::vector<RawStates> compute_next_raw_states(State* state, const Bitset& evaluation) {
     assert(state != nullptr);
     auto states_vector = get_states_from_bitset(state->states);
     std::map<VariablesToMark, StateStates> computed_raw_states;

--- a/src/core_server/internal/evaluation/det_cea/state.hpp
+++ b/src/core_server/internal/evaluation/det_cea/state.hpp
@@ -94,7 +94,7 @@ class State {
   }
 
   std::optional<std::reference_wrapper<TransitionTargetStatesWithMarkings>>
-  next(Bitset evaluation, uint64_t& n_hits) {
+  next(const Bitset& evaluation, uint64_t& n_hits) {
     assert(next_evictable_state == nullptr && prev_evictable_state == nullptr);
     auto it = transitions.find(evaluation);
     if (it != transitions.end()) {
@@ -110,13 +110,13 @@ class State {
   }
 
   std::reference_wrapper<TransitionTargetStatesWithMarkings>
-  add_transition(Bitset evaluation, TransitionTargetStatesWithMarkings next_states) {
+  add_transition(const Bitset& evaluation,
+                 TransitionTargetStatesWithMarkings next_states) {
     assert(!transitions.contains(evaluation));
     for (auto& [state, marked_variables] : next_states.state_marked_variables_pair) {
       assert(state != nullptr);
     }
-    auto it = transitions.insert(
-      std::make_pair(std::move(evaluation), std::move(next_states)));
+    auto it = transitions.insert(std::make_pair(evaluation, std::move(next_states)));
     TransitionTargetStatesWithMarkings& transition_target = it.first->second;
     return transition_target;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved memory efficiency and reduced unnecessary copies in state evaluation pathways, resulting in lower memory usage and faster transitions.
  * Strengthened const-correctness and ownership handling to increase stability and maintain existing behavior under heavy evaluation workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->