### PR TITLE
fix: harden online stream message decoding

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -36,9 +36,9 @@ jobs:
           create-symlink: true
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -142,7 +142,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,9 +31,9 @@ jobs:
           create-symlink: true
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -94,9 +94,9 @@ jobs:
           create-symlink: true
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -140,9 +140,9 @@ jobs:
           create-symlink: true
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/sanitizer-wheels.yaml
+++ b/.github/workflows/sanitizer-wheels.yaml
@@ -33,9 +33,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7.3.0
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/sanitizer-wheels.yaml
+++ b/.github/workflows/sanitizer-wheels.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/test-checks.yaml
+++ b/.github/workflows/test-checks.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -91,7 +91,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -149,7 +149,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -206,7 +206,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -267,7 +267,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -324,7 +324,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -385,7 +385,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -455,7 +455,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/test-checks.yaml
+++ b/.github/workflows/test-checks.yaml
@@ -34,9 +34,9 @@ jobs:
           echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "$GITHUB_ENV"
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -89,9 +89,9 @@ jobs:
           echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "$GITHUB_ENV"
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -147,9 +147,9 @@ jobs:
           echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "$GITHUB_ENV"
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -204,9 +204,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7.3.0
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -265,9 +265,9 @@ jobs:
           create-symlink: true
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -322,9 +322,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7.3.0
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -383,9 +383,9 @@ jobs:
           create-symlink: true
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |
@@ -453,9 +453,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7.3.0
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/valgrind-checks.yaml
+++ b/.github/workflows/valgrind-checks.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "19.1.7"
+          version: "22"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/.github/workflows/valgrind-checks.yaml
+++ b/.github/workflows/valgrind-checks.yaml
@@ -40,9 +40,9 @@ jobs:
           create-symlink: true
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: "22"
+          version: "21.1.8"
 
       - name: Install libtinfo5 for clang
         run: |

--- a/src/core_client/client.hpp
+++ b/src/core_client/client.hpp
@@ -38,6 +38,7 @@
 #include "shared/exceptions/parsing/parsing_syntax_exception.hpp"
 #include "shared/exceptions/parsing/stream_name_already_declared_exception.hpp"
 #include "shared/exceptions/parsing/stream_not_found_exception.hpp"
+#include "shared/networking/client_request_codec.hpp"
 #include "shared/networking/message_dealer/zmq_message_dealer.hpp"
 #include "shared/networking/message_subscriber/zmq_message_subscriber.hpp"
 #include "shared/serializer/cereal_serializer.hpp"
@@ -46,7 +47,6 @@
 namespace CORE {
 class Client {
   using SubscriptionId = uint64_t;
-  using ClientReqSerializer = Internal::CerealSerializer<Types::ClientRequest>;
   using ServerResSerializer = Internal::CerealSerializer<Types::ServerResponse>;
   using EnumeratorSerializer = Internal::CerealSerializer<Types::Enumerator>;
   std::unordered_set<Types::PortNumber> known_query_evaluator_ports;  // TODO
@@ -224,7 +224,7 @@ class Client {
 
  private:
   Types::ServerResponse send_request(Types::ClientRequest request) {
-    std::string serialized_request = ClientReqSerializer::serialize(request);
+    std::string serialized_request = Internal::ClientRequestCodec::serialize(request);
     auto serialized_response = dealer.send_and_receive(serialized_request);
     auto res = ServerResSerializer::deserialize(serialized_response);
     switch (res.response_type) {

--- a/src/core_server/library/components/client_message_handler.hpp
+++ b/src/core_server/library/components/client_message_handler.hpp
@@ -88,7 +88,7 @@ class ClientMessageHandler {
       }
 
       return CerealSerializer<Types::ServerResponse>::serialize(
-        handle_client_request(std::move(request.value())));
+        handle_client_request(request.value()));
     } catch (const std::exception& e) {
       LOG_ERROR(logger,
                 "Failed to process client request ({} bytes): {}",

--- a/src/core_server/library/components/client_message_handler.hpp
+++ b/src/core_server/library/components/client_message_handler.hpp
@@ -39,6 +39,7 @@
 #include "shared/exceptions/parsing/stream_name_already_declared_exception.hpp"
 #include "shared/exceptions/parsing/stream_not_found_exception.hpp"
 #include "shared/exceptions/parsing/warning_exception.hpp"
+#include "shared/networking/client_request_codec.hpp"
 #include "shared/serializer/cereal_serializer.hpp"
 
 namespace CORE::Library::Components {
@@ -78,8 +79,16 @@ class ClientMessageHandler {
   std::string operator()(const std::string& serialized_client_request) {
     std::lock_guard<std::mutex> lock(backend_mutex);
     try {
-      return CerealSerializer<Types::ServerResponse>::serialize(handle_client_request(
-        CerealSerializer<Types::ClientRequest>::deserialize(serialized_client_request)));
+      auto request = ClientRequestCodec::deserialize(serialized_client_request);
+      if (!request.has_value()) {
+        LOG_ERROR(logger,
+                  "Failed to process client request ({} bytes): malformed framed request",
+                  serialized_client_request.size());
+        return serialize_error_response("Failed to process client request.");
+      }
+
+      return CerealSerializer<Types::ServerResponse>::serialize(
+        handle_client_request(std::move(request.value())));
     } catch (const std::exception& e) {
       LOG_ERROR(logger,
                 "Failed to process client request ({} bytes): {}",

--- a/src/core_server/library/components/stream_listeners/online/online_streams_listener.hpp
+++ b/src/core_server/library/components/stream_listeners/online/online_streams_listener.hpp
@@ -76,6 +76,13 @@ class OnlineStreamsListener {
                      stream->events.size());
         std::lock_guard lock(backend_mutex);
         for (auto& event : stream->events) {
+          if (!event) {
+            LOG_TRACE_L3(logger,
+                         "Skipping null event for stream with id {} in "
+                         "OnlineStreamsListener",
+                         stream->id);
+            continue;
+          }
           LOG_TRACE_L3(logger,
                        "Stream with id {} and event {} in OnlineStreamsListener",
                        stream->id,

--- a/src/core_server/library/components/stream_listeners/online/online_streams_listener.hpp
+++ b/src/core_server/library/components/stream_listeners/online/online_streams_listener.hpp
@@ -5,6 +5,7 @@
 #include <quill/Logger.h>
 
 #include <atomic>
+#include <exception>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -15,7 +16,7 @@
 #include "shared/datatypes/aliases/port_number.hpp"
 #include "shared/datatypes/stream.hpp"
 #include "shared/networking/message_receiver/zmq_message_receiver.hpp"
-#include "shared/serializer/cereal_serializer.hpp"
+#include "shared/networking/stream_message_codec.hpp"
 
 namespace CORE::Library::Components {
 
@@ -54,22 +55,37 @@ class OnlineStreamsListener {
 
   void worker() {
     while (!stop_condition) {
-      std::optional<std::string> s_message = receiver.receive(100);
-      if (!s_message.has_value()) {
-        continue;
-      }
-      Types::Stream stream = Internal::CerealSerializer<Types::Stream>::deserialize(
-        s_message.value());
-      LOG_TRACE_L3(logger,
-                   "Received stream with id {} and {} events in OnlineStreamsListener",
-                   stream.id,
-                   stream.events.size());
-      for (auto& event : stream.events) {
+      try {
+        std::optional<std::string> s_message = receiver.receive(100);
+        if (!s_message.has_value()) {
+          continue;
+        }
+
+        auto stream = Internal::StreamMessageCodec::deserialize(s_message.value());
+        if (!stream.has_value()) {
+          LOG_WARNING(logger,
+                      "Discarding malformed stream payload ({} bytes) in "
+                      "OnlineStreamsListener",
+                      s_message->size());
+          continue;
+        }
+
         LOG_TRACE_L3(logger,
-                     "Stream with id {} and event {} in OnlineStreamsListener",
-                     stream.id,
-                     event->to_string());
-        backend.send_event_to_queries(stream.id, {std::move(event), logger});
+                     "Received stream with id {} and {} events in OnlineStreamsListener",
+                     stream->id,
+                     stream->events.size());
+        std::lock_guard lock(backend_mutex);
+        for (auto& event : stream->events) {
+          LOG_TRACE_L3(logger,
+                       "Stream with id {} and event {} in OnlineStreamsListener",
+                       stream->id,
+                       event->to_string());
+          backend.send_event_to_queries(stream->id, {std::move(event), logger});
+        }
+      } catch (const std::exception& e) {
+        LOG_ERROR(logger, "OnlineStreamsListener worker failed: {}", e.what());
+      } catch (...) {
+        LOG_ERROR(logger, "OnlineStreamsListener worker failed with unknown exception");
       }
     }
   }

--- a/src/core_streamer/streamer.hpp
+++ b/src/core_streamer/streamer.hpp
@@ -21,7 +21,7 @@ class Streamer {
   Streamer(std::string address, Types::PortNumber dealer_port)
       : sender(address + ":" + std::to_string(dealer_port)) {}
 
-  void send_stream(Types::Stream stream) {
+  void send_stream(const Types::Stream& stream) {
     sender.send(Internal::StreamMessageCodec::serialize(stream));
   }
 

--- a/src/core_streamer/streamer.hpp
+++ b/src/core_streamer/streamer.hpp
@@ -11,11 +11,10 @@
 #include "shared/datatypes/event.hpp"
 #include "shared/datatypes/stream.hpp"
 #include "shared/networking/message_sender/zmq_message_sender.hpp"
-#include "shared/serializer/cereal_serializer.hpp"
+#include "shared/networking/stream_message_codec.hpp"
 
 namespace CORE {
 class Streamer {
-  using StreamSerializer = Internal::CerealSerializer<Types::Stream>;
   Internal::ZMQMessageSender sender;
 
  public:
@@ -23,7 +22,7 @@ class Streamer {
       : sender(address + ":" + std::to_string(dealer_port)) {}
 
   void send_stream(Types::Stream stream) {
-    sender.send(StreamSerializer::serialize(stream));
+    sender.send(Internal::StreamMessageCodec::serialize(stream));
   }
 
   void send_stream(Types::StreamTypeId stream_id, std::shared_ptr<Types::Event>&& event) {

--- a/src/pybind/python_binding.cpp
+++ b/src/pybind/python_binding.cpp
@@ -370,7 +370,7 @@ NB_MODULE(pycer, m) {
 
         nb::class_<Streamer>(m, "PyStreamer")
             .def(nb::init<std::string, uint16_t>())
-            .def("send_stream", nb::overload_cast<Types::Stream>(&Streamer::send_stream))
+            .def("send_stream", nb::overload_cast<const Types::Stream&>(&Streamer::send_stream))
             .def("send_stream", [](Streamer& self, Types::StreamTypeId stream_id, std::shared_ptr<Types::Event> event) {
                 self.send_stream(stream_id, std::move(event));
             }, nb::arg("stream_id"), nb::arg("event"),

--- a/src/shared/datatypes/client_request.hpp
+++ b/src/shared/datatypes/client_request.hpp
@@ -26,13 +26,9 @@ struct ClientRequest {
    */
   ClientRequestType request_type;
 
-  ClientRequest() noexcept = default;
-
   ClientRequest(std::string&& serialized_request_data, ClientRequestType request_type)
       : serialized_request_data(std::move(serialized_request_data)),
         request_type(request_type) {}
-
-  ~ClientRequest() noexcept = default;
 
   template <class Archive>
   void serialize(Archive& archive) {

--- a/src/shared/datatypes/client_request.hpp
+++ b/src/shared/datatypes/client_request.hpp
@@ -23,8 +23,10 @@ struct ClientRequest {
    * The request type goes afterwards to have the padding in the end of
    * the class. ClientRequestType is 1 byte. In this case, we will still
    * have the same 3 bytes of padding though.
-   */
+  */
   ClientRequestType request_type;
+
+  ClientRequest() noexcept = default;
 
   ClientRequest(std::string&& serialized_request_data, ClientRequestType request_type)
       : serialized_request_data(std::move(serialized_request_data)),

--- a/src/shared/datatypes/client_request.hpp
+++ b/src/shared/datatypes/client_request.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 
 #include "shared/datatypes/client_request_type.hpp"
 
@@ -28,7 +29,8 @@ struct ClientRequest {
   ClientRequest() noexcept = default;
 
   ClientRequest(std::string&& serialized_request_data, ClientRequestType request_type)
-      : serialized_request_data(serialized_request_data), request_type(request_type) {}
+      : serialized_request_data(std::move(serialized_request_data)),
+        request_type(request_type) {}
 
   ~ClientRequest() noexcept = default;
 

--- a/src/shared/datatypes/client_request.hpp
+++ b/src/shared/datatypes/client_request.hpp
@@ -23,7 +23,7 @@ struct ClientRequest {
    * The request type goes afterwards to have the padding in the end of
    * the class. ClientRequestType is 1 byte. In this case, we will still
    * have the same 3 bytes of padding though.
-  */
+   */
   ClientRequestType request_type;
 
   ClientRequest() noexcept = default;

--- a/src/shared/networking/client_request_codec.hpp
+++ b/src/shared/networking/client_request_codec.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cereal/details/helpers.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "shared/datatypes/client_request.hpp"
+#include "shared/datatypes/client_request_type.hpp"
+#include "shared/serializer/cereal_serializer.hpp"
+
+namespace CORE::Internal {
+
+class ClientRequestCodec {
+ public:
+  static constexpr std::string_view kMagic = "CORECREQ";
+  static constexpr std::uint8_t kVersion = 1;
+  static constexpr std::size_t kHeaderSize = kMagic.size() + sizeof(kVersion);
+  static constexpr std::size_t kMaxPayloadSize = static_cast<const std::size_t>(64U
+                                                                                * 1024U)
+                                                 * 1024U;  // Maximum 64MiB
+  static constexpr std::size_t kMaxFrameSize = kHeaderSize + kMaxPayloadSize;
+
+ private:
+  using SerializedRequestType = std::underlying_type_t<Types::ClientRequestType>;
+
+  static bool has_magic_prefix(std::string_view message) {
+    return message.size() >= kMagic.size() && message.starts_with(kMagic);
+  }
+
+  static bool has_well_formed_payload(std::string_view payload) {
+    constexpr std::size_t kSerializedStringSizeBytes = sizeof(cereal::size_type);
+    constexpr std::size_t kSerializedRequestTypeBytes = sizeof(SerializedRequestType);
+    constexpr std::size_t kMinimumSerializedClientRequestSize = kSerializedStringSizeBytes
+                                                                + kSerializedRequestTypeBytes;
+
+    if (payload.size() < kMinimumSerializedClientRequestSize) {
+      return false;
+    }
+
+    cereal::size_type serialized_request_data_size = 0;
+    std::memcpy(&serialized_request_data_size,
+                payload.data(),
+                sizeof(serialized_request_data_size));
+
+    const std::size_t remaining_serialized_bytes = payload.size()
+                                                   - kMinimumSerializedClientRequestSize;
+
+    return serialized_request_data_size == remaining_serialized_bytes;
+  }
+
+ public:
+  static std::string serialize(const Types::ClientRequest& request) {
+    std::string payload = CerealSerializer<Types::ClientRequest>::serialize(request);
+    std::string framed_message;
+    framed_message.reserve(kHeaderSize + payload.size());
+    framed_message.append(kMagic);
+    framed_message.push_back(static_cast<char>(kVersion));
+    framed_message.append(payload);
+    return framed_message;
+  }
+
+  static std::optional<Types::ClientRequest> deserialize(std::string_view message) {
+    try {
+      if (!has_magic_prefix(message)) {
+        return std::nullopt;
+      }
+
+      if (message.size() <= kHeaderSize
+          || static_cast<std::uint8_t>(message[kMagic.size()]) != kVersion) {
+        return std::nullopt;
+      }
+
+      if (message.size() > kMaxFrameSize
+          || message.size() - kHeaderSize > kMaxPayloadSize) {
+        return std::nullopt;
+      }
+
+      const std::string_view payload = message.substr(kHeaderSize);
+      if (!has_well_formed_payload(payload)) {
+        return std::nullopt;
+      }
+
+      return CerealSerializer<Types::ClientRequest>::deserialize(payload);
+    } catch (...) {
+      return std::nullopt;
+    }
+  }
+};
+
+}  // namespace CORE::Internal

--- a/src/shared/networking/client_request_codec.hpp
+++ b/src/shared/networking/client_request_codec.hpp
@@ -11,6 +11,7 @@
 
 #include "shared/datatypes/client_request.hpp"
 #include "shared/datatypes/client_request_type.hpp"
+#include "shared/networking/framed_message.hpp"
 #include "shared/serializer/cereal_serializer.hpp"
 
 namespace CORE::Internal {
@@ -19,18 +20,15 @@ class ClientRequestCodec {
  public:
   static constexpr std::string_view kMagic = "CORECREQ";
   static constexpr std::uint8_t kVersion = 1;
-  static constexpr std::size_t kHeaderSize = kMagic.size() + sizeof(kVersion);
   static constexpr std::size_t kMaxPayloadSize = static_cast<const std::size_t>(64U
                                                                                 * 1024U)
                                                  * 1024U;  // Maximum 64MiB
-  static constexpr std::size_t kMaxFrameSize = kHeaderSize + kMaxPayloadSize;
+  static constexpr FramedMessageSpec kFrameSpec{kMagic, kVersion, kMaxPayloadSize};
+  static constexpr std::size_t kHeaderSize = framed_header_size(kFrameSpec);
+  static constexpr std::size_t kMaxFrameSize = framed_max_frame_size(kFrameSpec);
 
  private:
   using SerializedRequestType = std::underlying_type_t<Types::ClientRequestType>;
-
-  static bool has_magic_prefix(std::string_view message) {
-    return message.size() >= kMagic.size() && message.starts_with(kMagic);
-  }
 
   static bool has_well_formed_payload(std::string_view payload) {
     constexpr std::size_t kSerializedStringSizeBytes = sizeof(cereal::size_type);
@@ -55,37 +53,23 @@ class ClientRequestCodec {
 
  public:
   static std::string serialize(const Types::ClientRequest& request) {
-    std::string payload = CerealSerializer<Types::ClientRequest>::serialize(request);
-    std::string framed_message;
-    framed_message.reserve(kHeaderSize + payload.size());
-    framed_message.append(kMagic);
-    framed_message.push_back(static_cast<char>(kVersion));
-    framed_message.append(payload);
-    return framed_message;
+    return serialize_framed_payload(CerealSerializer<Types::ClientRequest>::serialize(
+                                      request),
+                                    kFrameSpec);
   }
 
   static std::optional<Types::ClientRequest> deserialize(std::string_view message) {
     try {
-      if (!has_magic_prefix(message)) {
+      auto payload = extract_framed_payload(message, kFrameSpec);
+      if (!payload.has_value()) {
         return std::nullopt;
       }
 
-      if (message.size() <= kHeaderSize
-          || static_cast<std::uint8_t>(message[kMagic.size()]) != kVersion) {
+      if (!has_well_formed_payload(payload.value())) {
         return std::nullopt;
       }
 
-      if (message.size() > kMaxFrameSize
-          || message.size() - kHeaderSize > kMaxPayloadSize) {
-        return std::nullopt;
-      }
-
-      const std::string_view payload = message.substr(kHeaderSize);
-      if (!has_well_formed_payload(payload)) {
-        return std::nullopt;
-      }
-
-      return CerealSerializer<Types::ClientRequest>::deserialize(payload);
+      return CerealSerializer<Types::ClientRequest>::deserialize(payload.value());
     } catch (...) {
       return std::nullopt;
     }

--- a/src/shared/networking/framed_message.hpp
+++ b/src/shared/networking/framed_message.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace CORE::Internal {
+
+struct FramedMessageSpec {
+  std::string_view magic;
+  std::uint8_t version;
+  std::size_t max_payload_size;
+};
+
+constexpr std::size_t framed_header_size(const FramedMessageSpec& spec) {
+  return spec.magic.size() + sizeof(spec.version);
+}
+
+constexpr std::size_t framed_max_frame_size(const FramedMessageSpec& spec) {
+  return framed_header_size(spec) + spec.max_payload_size;
+}
+
+inline std::string
+serialize_framed_payload(std::string_view payload, const FramedMessageSpec& spec) {
+  std::string framed_message;
+  framed_message.reserve(framed_header_size(spec) + payload.size());
+  framed_message.append(spec.magic);
+  framed_message.push_back(static_cast<char>(spec.version));
+  framed_message.append(payload);
+  return framed_message;
+}
+
+inline std::optional<std::string_view>
+extract_framed_payload(std::string_view message, const FramedMessageSpec& spec) {
+  if (message.size() < spec.magic.size() || !message.starts_with(spec.magic)) {
+    return std::nullopt;
+  }
+
+  if (message.size() <= framed_header_size(spec)
+      || static_cast<std::uint8_t>(message[spec.magic.size()]) != spec.version) {
+    return std::nullopt;
+  }
+
+  if (message.size() > framed_max_frame_size(spec)
+      || message.size() - framed_header_size(spec) > spec.max_payload_size) {
+    return std::nullopt;
+  }
+
+  return message.substr(framed_header_size(spec));
+}
+
+}  // namespace CORE::Internal

--- a/src/shared/networking/stream_message_codec.hpp
+++ b/src/shared/networking/stream_message_codec.hpp
@@ -18,7 +18,7 @@ class StreamMessageCodec {
   static constexpr std::size_t kHeaderSize = kMagic.size() + sizeof(kVersion);
 
   static bool has_magic_prefix(std::string_view message) {
-    return message.size() >= kMagic.size() && message.substr(0, kMagic.size()) == kMagic;
+    return message.size() >= kMagic.size() && message.starts_with(kMagic);
   }
 
  public:

--- a/src/shared/networking/stream_message_codec.hpp
+++ b/src/shared/networking/stream_message_codec.hpp
@@ -12,11 +12,16 @@
 namespace CORE::Internal {
 
 class StreamMessageCodec {
- private:
+ public:
   static constexpr std::string_view kMagic = "CORESTRM";
   static constexpr std::uint8_t kVersion = 1;
   static constexpr std::size_t kHeaderSize = kMagic.size() + sizeof(kVersion);
+  static constexpr std::size_t kMaxPayloadSize = static_cast<const std::size_t>(64U
+                                                                                * 1024U)
+                                                 * 1024U;  // Maximum 64MiB
+  static constexpr std::size_t kMaxFrameSize = kHeaderSize + kMaxPayloadSize;
 
+ private:
   static bool has_magic_prefix(std::string_view message) {
     return message.size() >= kMagic.size() && message.starts_with(kMagic);
   }
@@ -32,7 +37,7 @@ class StreamMessageCodec {
     return framed_message;
   }
 
-  static std::optional<Types::Stream> deserialize(const std::string& message) {
+  static std::optional<Types::Stream> deserialize(std::string_view message) {
     try {
       // Any message should have the magic prefix
       if (!has_magic_prefix(message)) {
@@ -42,6 +47,11 @@ class StreamMessageCodec {
       // Message needs to be a valid version
       if (message.size() <= kHeaderSize
           || static_cast<std::uint8_t>(message[kMagic.size()]) != kVersion) {
+        return std::nullopt;
+      }
+
+      if (message.size() > kMaxFrameSize
+          || message.size() - kHeaderSize > kMaxPayloadSize) {
         return std::nullopt;
       }
 

--- a/src/shared/networking/stream_message_codec.hpp
+++ b/src/shared/networking/stream_message_codec.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 
 #include "shared/datatypes/stream.hpp"
+#include "shared/networking/framed_message.hpp"
 #include "shared/serializer/cereal_serializer.hpp"
 
 namespace CORE::Internal {
@@ -15,47 +16,27 @@ class StreamMessageCodec {
  public:
   static constexpr std::string_view kMagic = "CORESTRM";
   static constexpr std::uint8_t kVersion = 1;
-  static constexpr std::size_t kHeaderSize = kMagic.size() + sizeof(kVersion);
   static constexpr std::size_t kMaxPayloadSize = static_cast<const std::size_t>(64U
                                                                                 * 1024U)
                                                  * 1024U;  // Maximum 64MiB
-  static constexpr std::size_t kMaxFrameSize = kHeaderSize + kMaxPayloadSize;
-
- private:
-  static bool has_magic_prefix(std::string_view message) {
-    return message.size() >= kMagic.size() && message.starts_with(kMagic);
-  }
+  static constexpr FramedMessageSpec kFrameSpec{kMagic, kVersion, kMaxPayloadSize};
+  static constexpr std::size_t kHeaderSize = framed_header_size(kFrameSpec);
+  static constexpr std::size_t kMaxFrameSize = framed_max_frame_size(kFrameSpec);
 
  public:
   static std::string serialize(const Types::Stream& stream) {
-    std::string payload = CerealSerializer<Types::Stream>::serialize(stream);
-    std::string framed_message;
-    framed_message.reserve(kHeaderSize + payload.size());
-    framed_message.append(kMagic);
-    framed_message.push_back(static_cast<char>(kVersion));
-    framed_message.append(payload);
-    return framed_message;
+    return serialize_framed_payload(CerealSerializer<Types::Stream>::serialize(stream),
+                                    kFrameSpec);
   }
 
   static std::optional<Types::Stream> deserialize(std::string_view message) {
     try {
-      // Any message should have the magic prefix
-      if (!has_magic_prefix(message)) {
+      auto payload = extract_framed_payload(message, kFrameSpec);
+      if (!payload.has_value()) {
         return std::nullopt;
       }
 
-      // Message needs to be a valid version
-      if (message.size() <= kHeaderSize
-          || static_cast<std::uint8_t>(message[kMagic.size()]) != kVersion) {
-        return std::nullopt;
-      }
-
-      if (message.size() > kMaxFrameSize
-          || message.size() - kHeaderSize > kMaxPayloadSize) {
-        return std::nullopt;
-      }
-
-      return CerealSerializer<Types::Stream>::deserialize(message.substr(kHeaderSize));
+      return CerealSerializer<Types::Stream>::deserialize(payload.value());
     } catch (...) {
       return std::nullopt;
     }

--- a/src/shared/networking/stream_message_codec.hpp
+++ b/src/shared/networking/stream_message_codec.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "shared/datatypes/stream.hpp"
+#include "shared/serializer/cereal_serializer.hpp"
+
+namespace CORE::Internal {
+
+class StreamMessageCodec {
+ private:
+  static constexpr std::string_view kMagic = "CORESTRM";
+  static constexpr std::uint8_t kVersion = 1;
+  static constexpr std::size_t kHeaderSize = kMagic.size() + sizeof(kVersion);
+
+  static bool has_magic_prefix(std::string_view message) {
+    return message.size() >= kMagic.size() && message.substr(0, kMagic.size()) == kMagic;
+  }
+
+ public:
+  static std::string serialize(const Types::Stream& stream) {
+    std::string payload = CerealSerializer<Types::Stream>::serialize(stream);
+    std::string framed_message;
+    framed_message.reserve(kHeaderSize + payload.size());
+    framed_message.append(kMagic);
+    framed_message.push_back(static_cast<char>(kVersion));
+    framed_message.append(payload);
+    return framed_message;
+  }
+
+  static std::optional<Types::Stream> deserialize(const std::string& message) {
+    try {
+      // Any message should have the magic prefix
+      if (!has_magic_prefix(message)) {
+        return std::nullopt;
+      }
+
+      // Message needs to be a valid version
+      if (message.size() <= kHeaderSize
+          || static_cast<std::uint8_t>(message[kMagic.size()]) != kVersion) {
+        return std::nullopt;
+      }
+
+      return CerealSerializer<Types::Stream>::deserialize(message.substr(kHeaderSize));
+    } catch (...) {
+      return std::nullopt;
+    }
+  }
+};
+
+}  // namespace CORE::Internal

--- a/src/shared/serializer/cereal_serializer.hpp
+++ b/src/shared/serializer/cereal_serializer.hpp
@@ -29,8 +29,11 @@
 #include <cereal/types/valarray.hpp>
 #include <cereal/types/variant.hpp>
 #include <cereal/types/vector.hpp>
+#include <istream>
 #include <sstream>
+#include <streambuf>
 #include <string>
+#include <string_view>
 // NOLINTEND
 
 #include "shared/serializer/serializer.hpp"
@@ -38,6 +41,15 @@
 namespace CORE::Internal {
 template <typename StructName>
 class CerealSerializer : Serializer<StructName> {
+ private:
+  class MemoryInputBuffer final : public std::streambuf {
+   public:
+    explicit MemoryInputBuffer(std::string_view message) {
+      char* begin = message.empty() ? nullptr : const_cast<char*>(message.data());
+      setg(begin, begin, begin == nullptr ? nullptr : begin + message.size());
+    }
+  };
+
  public:
   static std::string serialize(const StructName& data) {
     std::stringstream ss;
@@ -46,10 +58,11 @@ class CerealSerializer : Serializer<StructName> {
     return ss.str();
   }
 
-  static StructName deserialize(const std::string& message) {
-    std::stringstream ss(message);
+  static StructName deserialize(std::string_view message) {
+    MemoryInputBuffer buffer(message);
+    std::istream input(&buffer);
     StructName data;
-    cereal::BinaryInputArchive iarchive(ss);
+    cereal::BinaryInputArchive iarchive(input);
     iarchive(data);
     return data;
   }

--- a/src/shared/serializer/serializer.hpp
+++ b/src/shared/serializer/serializer.hpp
@@ -1,10 +1,11 @@
 #include <string>
+#include <string_view>
 
 namespace CORE::Internal {
 template <typename StructName>
 class Serializer {
  public:
   static std::string serialize(const StructName);
-  StructName deserialize(const std::string& message);
+  static StructName deserialize(std::string_view message);
 };
 }  // namespace CORE::Internal

--- a/src/tests/unit_tests/core_server/library/client_message_handler.cpp
+++ b/src/tests/unit_tests/core_server/library/client_message_handler.cpp
@@ -52,8 +52,7 @@ TEST_CASE("ClientMessageHandler returns an error response for unknown request ty
   auto result_handler_factory = std::make_shared<OfflineResultHandlerFactory>();
   ClientMessageHandler handler(backend, backend_mutex, result_handler_factory);
 
-  const auto valid_request = Types::ClientRequest("",
-                                                  Types::ClientRequestType::AddQuery);
+  const auto valid_request = Types::ClientRequest("", Types::ClientRequestType::AddQuery);
   auto serialized_request = Internal::ClientRequestCodec::serialize(valid_request);
   serialized_request.back() = static_cast<char>(0xff);
 

--- a/src/tests/unit_tests/core_server/library/client_message_handler.cpp
+++ b/src/tests/unit_tests/core_server/library/client_message_handler.cpp
@@ -52,10 +52,10 @@ TEST_CASE("ClientMessageHandler returns an error response for unknown request ty
   auto result_handler_factory = std::make_shared<OfflineResultHandlerFactory>();
   ClientMessageHandler handler(backend, backend_mutex, result_handler_factory);
 
-  const auto invalid_request = Types::ClientRequest("",
-                                                    static_cast<Types::ClientRequestType>(
-                                                      255));
-  const auto serialized_request = Internal::ClientRequestCodec::serialize(invalid_request);
+  const auto valid_request = Types::ClientRequest("",
+                                                  Types::ClientRequestType::AddQuery);
+  auto serialized_request = Internal::ClientRequestCodec::serialize(valid_request);
+  serialized_request.back() = static_cast<char>(0xff);
 
   const auto serialized_response = handler(serialized_request);
   const auto response = Internal::CerealSerializer<Types::ServerResponse>::deserialize(

--- a/src/tests/unit_tests/core_server/library/client_message_handler.cpp
+++ b/src/tests/unit_tests/core_server/library/client_message_handler.cpp
@@ -12,6 +12,7 @@
 #include "shared/datatypes/server_response.hpp"
 #include "shared/datatypes/server_response_type.hpp"
 #include "shared/logging/setup.hpp"
+#include "shared/networking/client_request_codec.hpp"
 #include "shared/serializer/cereal_serializer.hpp"
 
 namespace CORE::Library::Components::UnitTests {
@@ -54,8 +55,7 @@ TEST_CASE("ClientMessageHandler returns an error response for unknown request ty
   const auto invalid_request = Types::ClientRequest("",
                                                     static_cast<Types::ClientRequestType>(
                                                       255));
-  const auto serialized_request = Internal::CerealSerializer<Types::ClientRequest>::serialize(
-    invalid_request);
+  const auto serialized_request = Internal::ClientRequestCodec::serialize(invalid_request);
 
   const auto serialized_response = handler(serialized_request);
   const auto response = Internal::CerealSerializer<Types::ServerResponse>::deserialize(

--- a/src/tests/unit_tests/core_server/library/client_request_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/client_request_codec.cpp
@@ -14,8 +14,8 @@ TEST_CASE("ClientRequestCodec deserializes framed client requests",
   Types::ClientRequest request("payload", Types::ClientRequestType::AddQuery);
 
   std::string framed_message = Internal::ClientRequestCodec::serialize(request);
-  std::optional<Types::ClientRequest> decoded_request = Internal::ClientRequestCodec::deserialize(
-    framed_message);
+  std::optional<Types::ClientRequest>
+    decoded_request = Internal::ClientRequestCodec::deserialize(framed_message);
 
   REQUIRE(decoded_request.has_value());
   REQUIRE(decoded_request->serialized_request_data == request.serialized_request_data);
@@ -35,8 +35,8 @@ TEST_CASE("ClientRequestCodec rejects malformed wire payloads without throwing",
 
 TEST_CASE("ClientRequestCodec rejects malformed framed payloads without throwing",
           "[client_request_codec]") {
-  constexpr char malformed_serialized_request_payload[]
-    = "\0\0\0\0Cookie: mstshash=Administr\r\n\001\000\b\000\003\000\000";
+  constexpr char malformed_serialized_request_payload
+    [] = "\0\0\0\0Cookie: mstshash=Administr\r\n\001\000\b\000\003\000\000";
 
   std::string malformed_message(Internal::ClientRequestCodec::kMagic);
   malformed_message.push_back(static_cast<char>(Internal::ClientRequestCodec::kVersion));

--- a/src/tests/unit_tests/core_server/library/client_request_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/client_request_codec.cpp
@@ -1,5 +1,6 @@
 #include "shared/networking/client_request_codec.hpp"
 
+#include <cassert>
 #include <catch2/catch_test_macros.hpp>
 #include <optional>
 #include <string>
@@ -18,6 +19,7 @@ TEST_CASE("ClientRequestCodec deserializes framed client requests",
     decoded_request = Internal::ClientRequestCodec::deserialize(framed_message);
 
   REQUIRE(decoded_request.has_value());
+  assert(decoded_request.has_value());
   REQUIRE(decoded_request->serialized_request_data == request.serialized_request_data);
   REQUIRE(decoded_request->request_type == request.request_type);
 }

--- a/src/tests/unit_tests/core_server/library/client_request_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/client_request_codec.cpp
@@ -32,7 +32,7 @@ TEST_CASE("ClientRequestCodec rejects malformed wire payloads without throwing",
   const std::string malformed_message(malformed_wire_payload,
                                       sizeof(malformed_wire_payload) - 1);
 
-  REQUIRE_FALSE(Internal::ClientRequestCodec::deserialize(malformed_message).has_value());
+  REQUIRE(!Internal::ClientRequestCodec::deserialize(malformed_message).has_value());
 }
 
 TEST_CASE("ClientRequestCodec rejects malformed framed payloads without throwing",
@@ -45,7 +45,7 @@ TEST_CASE("ClientRequestCodec rejects malformed framed payloads without throwing
   malformed_message.append(malformed_serialized_request_payload,
                            sizeof(malformed_serialized_request_payload) - 1);
 
-  REQUIRE_FALSE(Internal::ClientRequestCodec::deserialize(malformed_message).has_value());
+  REQUIRE(!Internal::ClientRequestCodec::deserialize(malformed_message).has_value());
 }
 
 TEST_CASE("ClientRequestCodec rejects oversized frames before decoding",
@@ -54,7 +54,7 @@ TEST_CASE("ClientRequestCodec rejects oversized frames before decoding",
   oversized_message.push_back(static_cast<char>(Internal::ClientRequestCodec::kVersion));
   oversized_message.resize(Internal::ClientRequestCodec::kMaxFrameSize + 1, '\0');
 
-  REQUIRE_FALSE(Internal::ClientRequestCodec::deserialize(oversized_message).has_value());
+  REQUIRE(!Internal::ClientRequestCodec::deserialize(oversized_message).has_value());
 }
 
 }  // namespace CORE::Library::Components::UnitTests

--- a/src/tests/unit_tests/core_server/library/client_request_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/client_request_codec.cpp
@@ -1,0 +1,58 @@
+#include "shared/networking/client_request_codec.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+
+#include "shared/datatypes/client_request.hpp"
+#include "shared/datatypes/client_request_type.hpp"
+
+namespace CORE::Library::Components::UnitTests {
+
+TEST_CASE("ClientRequestCodec deserializes framed client requests",
+          "[client_request_codec]") {
+  Types::ClientRequest request("payload", Types::ClientRequestType::AddQuery);
+
+  std::string framed_message = Internal::ClientRequestCodec::serialize(request);
+  std::optional<Types::ClientRequest> decoded_request = Internal::ClientRequestCodec::deserialize(
+    framed_message);
+
+  REQUIRE(decoded_request.has_value());
+  REQUIRE(decoded_request->serialized_request_data == request.serialized_request_data);
+  REQUIRE(decoded_request->request_type == request.request_type);
+}
+
+TEST_CASE("ClientRequestCodec rejects malformed wire payloads without throwing",
+          "[client_request_codec]") {
+  constexpr char malformed_wire_payload[] =
+    "\x16\x03\x01\x00\x4d\x01\x00\x00\x49\x03\x03\x53\x43\x5b\x90"
+    "\xc0\x2f\xc0\x2b\xc0\x11\xc0\x07\xc0\x13\xc0\x09\xc0\x14\xc0\x0a";
+  const std::string malformed_message(malformed_wire_payload,
+                                      sizeof(malformed_wire_payload) - 1);
+
+  REQUIRE_FALSE(Internal::ClientRequestCodec::deserialize(malformed_message).has_value());
+}
+
+TEST_CASE("ClientRequestCodec rejects malformed framed payloads without throwing",
+          "[client_request_codec]") {
+  constexpr char malformed_serialized_request_payload[]
+    = "\0\0\0\0Cookie: mstshash=Administr\r\n\001\000\b\000\003\000\000";
+
+  std::string malformed_message(Internal::ClientRequestCodec::kMagic);
+  malformed_message.push_back(static_cast<char>(Internal::ClientRequestCodec::kVersion));
+  malformed_message.append(malformed_serialized_request_payload,
+                           sizeof(malformed_serialized_request_payload) - 1);
+
+  REQUIRE_FALSE(Internal::ClientRequestCodec::deserialize(malformed_message).has_value());
+}
+
+TEST_CASE("ClientRequestCodec rejects oversized frames before decoding",
+          "[client_request_codec]") {
+  std::string oversized_message(Internal::ClientRequestCodec::kMagic);
+  oversized_message.push_back(static_cast<char>(Internal::ClientRequestCodec::kVersion));
+  oversized_message.resize(Internal::ClientRequestCodec::kMaxFrameSize + 1, '\0');
+
+  REQUIRE_FALSE(Internal::ClientRequestCodec::deserialize(oversized_message).has_value());
+}
+
+}  // namespace CORE::Library::Components::UnitTests

--- a/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
@@ -24,7 +24,8 @@ TEST_CASE("StreamMessageCodec deserializes framed stream payloads",
   Types::Stream stream(5, {event});
 
   std::string framed_message = Internal::StreamMessageCodec::serialize(stream);
-  std::optional<Types::Stream> decoded_stream = Internal::StreamMessageCodec::deserialize(framed_message);
+  std::optional<Types::Stream> decoded_stream = Internal::StreamMessageCodec::deserialize(
+    framed_message);
 
   REQUIRE(decoded_stream.has_value());
   assert(decoded_stream.has_value());

--- a/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
@@ -1,0 +1,47 @@
+#include "shared/networking/stream_message_codec.hpp"
+
+#include <cassert>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "shared/datatypes/event.hpp"
+#include "shared/datatypes/stream.hpp"
+#include "shared/datatypes/value.hpp"
+
+namespace CORE::Library::Components::UnitTests {
+
+TEST_CASE("StreamMessageCodec deserializes framed stream payloads",
+          "[stream_message_codec]") {
+  std::vector<std::shared_ptr<Types::Value>> attributes;
+  attributes.push_back(std::make_shared<Types::IntValue>(42));
+  auto event = std::make_shared<Types::Event>(11,
+                                              std::move(attributes),
+                                              Types::IntValue(7));
+  Types::Stream stream(5, {event});
+
+  std::string framed_message = Internal::StreamMessageCodec::serialize(stream);
+  std::optional<Types::Stream> decoded_stream = Internal::StreamMessageCodec::deserialize(framed_message);
+
+  REQUIRE(decoded_stream.has_value());
+  assert(decoded_stream.has_value());
+  REQUIRE(decoded_stream->id == stream.id);
+  REQUIRE(decoded_stream->events.size() == 1);
+  REQUIRE(decoded_stream->events.front()->get_event_type_id() == 11);
+}
+
+TEST_CASE("StreamMessageCodec rejects malformed wire payloads without throwing",
+          "[stream_message_codec]") {
+  constexpr char malformed_wire_payload[] =
+    "\x16\x03\x01\x00\x4d\x01\x00\x00\x49\x03\x03\x53\x43\x5b\x90"
+    "\xc0\x2f\xc0\x2b\xc0\x11\xc0\x07\xc0\x13\xc0\x09\xc0\x14\xc0\x0a";
+  const std::string malformed_message(malformed_wire_payload,
+                                      sizeof(malformed_wire_payload) - 1);
+
+  REQUIRE_FALSE(Internal::StreamMessageCodec::deserialize(malformed_message).has_value());
+}
+
+}  // namespace CORE::Library::Components::UnitTests

--- a/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
@@ -45,4 +45,13 @@ TEST_CASE("StreamMessageCodec rejects malformed wire payloads without throwing",
   REQUIRE_FALSE(Internal::StreamMessageCodec::deserialize(malformed_message).has_value());
 }
 
+TEST_CASE("StreamMessageCodec rejects oversized frames before decoding",
+          "[stream_message_codec]") {
+  std::string oversized_message(Internal::StreamMessageCodec::kMagic);
+  oversized_message.push_back(static_cast<char>(Internal::StreamMessageCodec::kVersion));
+  oversized_message.resize(Internal::StreamMessageCodec::kMaxFrameSize + 1, '\0');
+
+  REQUIRE_FALSE(Internal::StreamMessageCodec::deserialize(oversized_message).has_value());
+}
+
 }  // namespace CORE::Library::Components::UnitTests

--- a/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
+++ b/src/tests/unit_tests/core_server/library/stream_message_codec.cpp
@@ -42,7 +42,7 @@ TEST_CASE("StreamMessageCodec rejects malformed wire payloads without throwing",
   const std::string malformed_message(malformed_wire_payload,
                                       sizeof(malformed_wire_payload) - 1);
 
-  REQUIRE_FALSE(Internal::StreamMessageCodec::deserialize(malformed_message).has_value());
+  REQUIRE(!Internal::StreamMessageCodec::deserialize(malformed_message).has_value());
 }
 
 TEST_CASE("StreamMessageCodec rejects oversized frames before decoding",
@@ -51,7 +51,7 @@ TEST_CASE("StreamMessageCodec rejects oversized frames before decoding",
   oversized_message.push_back(static_cast<char>(Internal::StreamMessageCodec::kVersion));
   oversized_message.resize(Internal::StreamMessageCodec::kMaxFrameSize + 1, '\0');
 
-  REQUIRE_FALSE(Internal::StreamMessageCodec::deserialize(oversized_message).has_value());
+  REQUIRE(!Internal::StreamMessageCodec::deserialize(oversized_message).has_value());
 }
 
 }  // namespace CORE::Library::Components::UnitTests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added framed message codecs and framing utilities for streams and client requests.

* **Bug Fixes**
  * Safer stream handling: robust decoding, skip malformed/oversized payloads, isolate exceptions, and thread-safe event processing.
  * Client requests now reject malformed frames and return framed error responses.

* **Tests**
  * Added unit tests for codec round-trips, malformed payloads, and oversized-frame rejection.

* **Chores / API**
  * Stream send API now takes streams by const reference; small client-request constructor/destructor cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->