### PR TITLE
fix: add type annotations to pycer stub generation

### DIFF
--- a/src/pybind/python_binding.cpp
+++ b/src/pybind/python_binding.cpp
@@ -339,7 +339,8 @@ NB_MODULE(pycer, m) {
                     }
                 }
                 return result;
-            });
+            },
+            nb::sig("def get_attributes_as_list(self) -> list[int | float | str | bool]"));
 
         nb::class_<Types::EventInfoParsed>(m, "PyEventInfoParsed")
             .def(nb::init<std::string, std::vector<Types::AttributeInfo>>())
@@ -411,7 +412,8 @@ NB_MODULE(pycer, m) {
                     result.append(entry);
                 }
                 return result;
-            });
+            },
+            nb::sig("def get_attribute_projection_stream_event(self) -> list[dict[str, str | list[str]]]"));
 
         nb::class_<PyClientWrapper>(m, "PyClient")
             .def(nb::init<std::string, uint16_t>())


### PR DESCRIPTION
## Summary
- Add `nb::sig()` return type annotations for two lambda bindings that return `nb::list`, so nanobind generates typed stubs instead of bare `list`
- `get_attributes_as_list` → `list[int | float | str | bool]`
- `get_attribute_projection_stream_event` → `list[dict[str, str | list[str]]]`

## Test plan
- [ ] Rebuild pycer with `scripts/build_pycer.sh`
- [ ] Verify `pycer.pyi` contains typed return signatures for both methods
- [ ] Run `basedpyright` on core-python-backend — should pass with zero inline ignores